### PR TITLE
Bug fix: not pushing packages to Nuget

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ for:
     skip_symbols: true
     artifact: /Seq.Input.Syslog.*\.nupkg/
     on:
-      branch: /^(dev|release/.*)$/
+      branch: /^(dev|release)$/
 -
   matrix:
     only:


### PR DESCRIPTION
The current regex is apparently not valid (unescaped forward slash)